### PR TITLE
Activate Travis for the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
+addons:
+  postgresql: "9.6"
 cache: cargo
 language: rust
 rust:
   - nightly
   - stable
-script:
-  - cargo test --verbose
-
 # Faster container-based builds
 sudo: false
+
+env:
+  - DATABASE_URL=postgres://localhost/pod_core
+
+before_script:
+  - cargo install diesel_cli --no-default-features --features postgres
+  - createdb pod_core
+  - diesel migration run
+
+script:
+  - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+cache: cargo
+language: rust
+rust:
+  - nightly
+  - stable
+script:
+  - cargo test --verbose
+
+# Faster container-based builds
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pod_core
+# pod_core [![Build Status](https://travis-ci.org/brandur/pod_core.svg?branch=master)](https://travis-ci.org/brandur/pod_core)
 
 ```
 cargo install diesel_cli --no-default-features --features postgres


### PR DESCRIPTION
Puts in a basic `.travis.yml` to start vetting the build in real life.