### PR TITLE
Switch to Rustfmt component instead of nightly crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,8 @@ before_script:
   - which diesel || cargo install diesel_cli --no-default-features --features postgres
   - createdb podcore-test
   - DATABASE_URL=$TEST_DATABASE_URL diesel migration run
+  - if [[ $NIGHTLY == 'true' ]]; then rustup component add rustfmt-preview; fi
   - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly install clippy --force; fi
-  - if [[ $NIGHTLY == 'true' ]]; then cargo install rustfmt-nightly --force; fi
-  # For some reason `which rustfmt` may show success even if `cargo fmt` fails.
-  # Add this back after this whole nightly-required disaster has ended.
-  #- if [[ $NIGHTLY == 'true' ]]; then which rustfmt || cargo install rustfmt-nightly --force; fi
 
 script:
   - cargo test --verbose
@@ -41,7 +38,10 @@ script:
   # specify that we want only a single test thread.
   - cargo test --verbose -- --ignored --test-threads=1
 
-  - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly fmt -- --write-mode=diff; fi
+  # Rustfmt is finally available as a preview component outside of nightly, but
+  # unfortunately we're using a few configuration options that are considered
+  # unstable so it still only works on nightly.
+  - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly fmt --all -- --write-mode=diff; fi
 
   # The `-D warnings` argument means that Clippy will send a non-zero exit code
   # if it encounters any linting problems (thus failing the build).

--- a/README.md
+++ b/README.md
@@ -37,13 +37,11 @@ Schema changes:
 diesel print-schema > src/schema.rs
 ```
 
-Rustfmt (run on `nightly` because rustfmt can't seem to detach itself from
-`nightly`)::
+Rustfmt:
 
 ```
-rustup install nightly
-cargo install rustfmt-nightly
-rustup run nightly cargo fmt
+rustup component add --toolchain=nightly rustfmt-preview
+cargo +nightly fmt
 ```
 
 Tests:


### PR DESCRIPTION
As of Rust 1.24, Rustfmt is now available as a preview component on
rustup, and it'll hopefully not be too much longer before it's available
as a stable one. Here we switch off the nightly Cargo crate and over to
the new component.